### PR TITLE
Remove unnecessary 32-bytes `ensureBytes` check in `sign` & `verify`

### DIFF
--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -127,7 +127,6 @@ export class HDKey {
   }
 
   sign(message: Hex): Uint8Array {
-    message = ensureBytes(message, 32);
     return ed25519.sign(message, this.privateKey);
   }
 

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -131,7 +131,6 @@ export class HDKey {
   }
 
   verify(message: Hex, signature: Hex): boolean {
-    message = ensureBytes(message, 32);
     signature = ensureBytes(signature, 64);
     return ed25519.verify(signature, message, this.publicKeyRaw);
   }

--- a/test/hdkey/index.test.mjs
+++ b/test/hdkey/index.test.mjs
@@ -27,9 +27,12 @@ should('throw on derivation of non-hardened keys', () => {
 should('signing', () => {
   const msgA = new Uint8Array(32);
   const msgB = new Uint8Array(32).fill(8);
+  const msgC = new Uint8Array(99).fill(8);
   const hdkey = HDKey.fromMasterSeed('000102030405060708090a0b0c0d0e0f').derive("m/0'");
   const sigA = hdkey.sign(msgA);
   const sigB = hdkey.sign(msgB);
+  const sigC = hdkey.sign(msgC);
+  console.log(sigB.length, sigC.length);
   deepStrictEqual(
     bytesToHex(sigA),
     '9280d4802b67760fb56274dcb43db877c4888e958831cb4a0d689cde7c3183b655d3a622c08ab0255a1f09c637b145776cb3327c9c2c776eb7aa464a241ce907'
@@ -38,11 +41,16 @@ should('signing', () => {
     bytesToHex(sigB),
     '2e44bdc615588392118b5d80d990660e55633f7dd21bb366a32d8445fba187ba35f1cbbdf96a0ab117eaadd9a0106a340d6028be455cf6851217dad6b9b23e06'
   );
+  deepStrictEqual(
+    bytesToHex(sigC),
+    'd8730a304b19fca3dfe8410de9150619efd6f186be7077cbc65b481d61e832b13f3965d4c792f8b1f81d54a89cc6b8d0ff179ef0affd8b863813f61d3615a404'
+  );
   deepStrictEqual(hdkey.verify(msgB, sigB), true);
+  deepStrictEqual(hdkey.verify(msgC, sigC), true);
   deepStrictEqual(hdkey.verify(new Uint8Array(32), new Uint8Array(64)), false);
   deepStrictEqual(hdkey.verify(msgA, sigB), false);
   deepStrictEqual(hdkey.verify(msgB, sigA), false);
-  throws(() => hdkey.verify(new Uint8Array(99), sigA));
+  deepStrictEqual(hdkey.verify(new Uint8Array(99), sigA), false);
   throws(() => hdkey.verify(msgA, new Uint8Array(99)));
 });
 


### PR DESCRIPTION
This PR aims to fix https://github.com/paulmillr/ed25519-keygen/issues/5